### PR TITLE
Add Swift Bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ typings/
 
 # gyp intermediate files
 *.gypi
+
+# Xcode-generated
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterAgda",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterAgda", targets: ["TreeSitterAgda"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterAgda",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "corpus",
+                    "grammar.js",
+                    "LICENSE",
+                    "package.json",
+                    "README.md",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.cc",
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterAgda/agda.h
+++ b/bindings/swift/TreeSitterAgda/agda.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_AGDA_H_
+#define TREE_SITTER_AGDA_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_agda();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_AGDA_H_


### PR DESCRIPTION
The Swift Package manager can build C and C++ sources and use headers to expose functions to Swift.

These additions and modifications allow the SPM to use the Agda Tree Sitter and for use in Swift apps.